### PR TITLE
Add In-Reply-To header

### DIFF
--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -129,7 +129,7 @@ class InboundEmail extends Model
     public function reply(Mailable $mailable)
     {
         if ($mailable instanceof \Illuminate\Mail\Mailable) {
-            $mailable->withSwiftMessage(function(\Swift_Message $message) {
+            $mailable->withSwiftMessage(function (\Swift_Message $message) {
                 $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
             });
         }

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -128,6 +128,12 @@ class InboundEmail extends Model
 
     public function reply(Mailable $mailable)
     {
+        if ($mailable instanceof \Illuminate\Mail\Mailable) {
+            $mailable->withSwiftMessage(function(\Swift_Message $message) {
+                $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
+            });
+        }
+
         return Mail::to($this->from())->send($mailable);
     }
 


### PR DESCRIPTION
I'm not sure about the real-world impact of this, but it should only improve threading etc.
See https://www.jwz.org/doc/threading.html
This let's the receiver know we intended to reply on that message and make it easier to thread (for example if the from e-mail is different). See https://support.cloudhq.net/how-does-gmail-decide-to-group-emails-into-conversations/
(Note that the subject should still be the same for this to have effect)

We check the actual implementation because the interface does not have the `withSwiftMessage` method, but it is described in the docs, see https://laravel.com/docs/5.7/mail#customizing-the-swiftmailer-message