### PR TITLE
Added basic auth middleware to PostmarkController

### DIFF
--- a/src/Http/Controllers/PostmarkController.php
+++ b/src/Http/Controllers/PostmarkController.php
@@ -2,11 +2,17 @@
 
 namespace BeyondCode\Mailbox\Http\Controllers;
 
+use Illuminate\Routing\Controller;
 use BeyondCode\Mailbox\Facades\Mailbox;
 use BeyondCode\Mailbox\Http\Requests\PostmarkRequest;
 
-class PostmarkController
+class PostmarkController extends Controller
 {
+	public function __construct()
+    {
+        $this->middleware('laravel-mailbox');
+    }
+
     public function __invoke(PostmarkRequest $request)
     {
         Mailbox::callMailboxes($request->email());

--- a/src/Http/Controllers/PostmarkController.php
+++ b/src/Http/Controllers/PostmarkController.php
@@ -8,7 +8,7 @@ use BeyondCode\Mailbox\Http\Requests\PostmarkRequest;
 
 class PostmarkController extends Controller
 {
-	public function __construct()
+    public function __construct()
     {
         $this->middleware('laravel-mailbox');
     }

--- a/tests/Controllers/PostmarkTest.php
+++ b/tests/Controllers/PostmarkTest.php
@@ -16,6 +16,8 @@ class PostmarkTest extends TestCase
     /** @test */
     public function it_expects_to_receive_raw_email_field()
     {
+        $this->withoutMiddleware();
+        
         $this->post('/laravel-mailbox/postmark', [
             'something' => 'value',
         ])->assertSessionHasErrors('RawEmail')->assertStatus(302);


### PR DESCRIPTION
Thanks to @asantibanez for adding Postmark support in #15 

I've added the `laravel-mailbox` middleware as per the Sendgrid controller, since Postmark recommends securing your webhook URL - https://postmarkapp.com/developer/webhooks/webhooks-overview#protecting-your-webhook