### PR TITLE
Added custom header getter

### DIFF
--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -172,7 +172,7 @@ class InboundEmail extends Model
         return $this->from() !== '' && ($this->text() !== '' || $this->html() !== '');
     }
     
-    public function headerValue(string $headerName): string
+    public function headerValue($headerName): string
     {
         return $this->message()->getHeaderValue($headerName, null);
     }

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -171,4 +171,9 @@ class InboundEmail extends Model
     {
         return $this->from() !== '' && ($this->text() !== '' || $this->html() !== '');
     }
+    
+    public function headerValue(string $headerName): string
+    {
+        return $this->message()->getHeaderValue($headerName, null);
+    }
 }

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -64,6 +64,11 @@ class InboundEmail extends Model
     {
         return $this->message()->getHtmlContent();
     }
+    
+    public function headerValue($headerName): string
+    {
+        return $this->message()->getHeaderValue($headerName, null);
+    }
 
     public function subject(): ?string
     {
@@ -170,10 +175,5 @@ class InboundEmail extends Model
     public function isValid(): bool
     {
         return $this->from() !== '' && ($this->text() !== '' || $this->html() !== '');
-    }
-    
-    public function headerValue($headerName): string
-    {
-        return $this->message()->getHeaderValue($headerName, null);
     }
 }


### PR DESCRIPTION
There were helpers for various header getters.

This one allows you to get the contents of any header, by specifying the header name.

Custom headers from Gmail for example, such as `X-Google-Smtp-Source:` can be used to further identify an email's origin etc.