### PR TITLE
Update log driver to listen to MessageSent event

### DIFF
--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -4,20 +4,24 @@ namespace BeyondCode\Mailbox\Drivers;
 
 use BeyondCode\Mailbox\InboundEmail;
 use BeyondCode\Mailbox\Facades\Mailbox;
-use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Mail\Events\MessageSent;
 
 class Log implements DriverInterface
 {
     public function register()
     {
-        app('events')->listen(MessageLogged::class, [$this, 'processLog']);
+        app('events')->listen(MessageSent::class, [$this, 'processLog']);
     }
 
-    public function processLog(MessageLogged $log)
+    public function processLog(MessageSent $event)
     {
+        if(config('mail.driver') !== 'log') {
+            return;    
+        }
+        
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
-        $email = $modelClass::fromMessage($log->message);
+        $email = $modelClass::fromMessage($event->message);
 
         Mailbox::callMailboxes($email);
     }

--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -15,10 +15,10 @@ class Log implements DriverInterface
 
     public function processLog(MessageSent $event)
     {
-        if(config('mail.driver') !== 'log') {
+        if (config('mail.driver') !== 'log') {
             return;    
         }
-        
+
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
         $email = $modelClass::fromMessage($event->message);

--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -16,7 +16,7 @@ class Log implements DriverInterface
     public function processLog(MessageSent $event)
     {
         if (config('mail.driver') !== 'log') {
-            return;    
+            return;
         }
 
         /** @var InboundEmail $modelClass */


### PR DESCRIPTION
The event is fired at the same time,
however this gives us access to the actual swift message rather than attempting to parse the message from the log meaning attachments and all the other goodies work.

Closes #25 