### PR TITLE
Add option to get the spam score and spam report from sendgrid on parse

### DIFF
--- a/src/Http/Requests/SendGridRequest.php
+++ b/src/Http/Requests/SendGridRequest.php
@@ -20,6 +20,6 @@ class SendGridRequest extends FormRequest
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
 
-        return $modelClass::fromMessage($this->get('email'));
+        return $modelClass::fromMessage($this->get('email'), $this->get('spam_score'), $this->get('spam_report'));
     }
 }

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -33,10 +33,12 @@ class InboundEmail extends Model
         });
     }
 
-    public static function fromMessage($message)
+    public static function fromMessage($message, $spam_score = null, $spam_report = null)
     {
         return new static([
             'message' => $message,
+            'spam_score' => $spam_score,
+            'spam_report' => $spam_report,
         ]);
     }
 
@@ -97,6 +99,16 @@ class InboundEmail extends Model
         return '';
     }
 
+    public function spamScore(): float
+    {
+        return $this->spam_score;
+    }
+
+    public function spamReport(): string
+    {
+        return $this->spam_report;
+    }
+
     /**
      * @return AddressPart[]
      */
@@ -125,7 +137,7 @@ class InboundEmail extends Model
     /**
      * @return MessagePart[]
      */
-    public function attachments()
+    public function attachments(): array
     {
         return $this->message()->getAllAttachmentParts();
     }


### PR DESCRIPTION
I've added the possibility to get the spam score for sendgrid. To filter out spam or not in the easy way. You can use the filter when parsing the message like this:

```php
Mailbox::catchAll(static function(InboundEmail $email) {
      echo $email->spamScore();
      echo $email->spamReport();
});
```