### PR TITLE
Use bigIncrements for primary key

### DIFF
--- a/database/migrations/create_mailbox_inbound_emails_table.php.stub
+++ b/database/migrations/create_mailbox_inbound_emails_table.php.stub
@@ -12,7 +12,7 @@ class CreateMailboxInboundEmailsTable extends Migration
     public function up()
     {
         Schema::create('mailbox_inbound_emails', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('message_id');
             $table->longText('message');
             $table->nullableTimestamps();


### PR DESCRIPTION
Laravel has switched to use `bigIncrements` in migrations.