### PR TITLE
Disable cleanup artisan command if store_incoming_emails_for_days is INF

### DIFF
--- a/config/mailbox.php
+++ b/config/mailbox.php
@@ -29,6 +29,7 @@ return [
      * The amount of days that incoming emails should be stored in your
      * application. You can use the cleanup artisan command to
      * delete all older inbound emails on a regular basis.
+     * Set to INF to disable the cleanup artisan command.
      */
     'store_incoming_emails_for_days' => 7,
 

--- a/src/Console/CleanEmails.php
+++ b/src/Console/CleanEmails.php
@@ -18,6 +18,12 @@ class CleanEmails extends Command
 
         $maxAgeInDays = config('mailbox.store_incoming_emails_for_days');
 
+        if ($maxAgeInDays === INF)
+        {
+            $this->error($this->signature . ' is disabled because store_incoming_emails_for_days is set to INF.');
+            return 1;
+        }
+
         $cutOffDate = Carbon::now()->subDay($maxAgeInDays)->format('Y-m-d H:i:s');
 
         /** @var InboundEmail $modelClass */


### PR DESCRIPTION
`Carbon::now()->subDay(INF) === Carbon::now()` so unexpected behaviour occurs unless we explicitly handle the INF case.