### PR TITLE
Fix local mail handling in Laravel 7.x

### DIFF
--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -15,7 +15,7 @@ class Log implements DriverInterface
 
     public function processLog(MessageSent $event)
     {
-        if (config('mail.driver') !== 'log') {
+        if (config('mail.default') !== 'log') {
             return;
         }
 


### PR DESCRIPTION
Laravel 7.x changed the config key for the mail driver to `default` instead of `driver`.
This PR fixes local mail debugging in Laravel 7.x