### PR TITLE
Fix Laravel 8 support

### DIFF
--- a/src/MailboxManager.php
+++ b/src/MailboxManager.php
@@ -43,6 +43,6 @@ class MailboxManager extends Manager
 
     public function getDefaultDriver()
     {
-        return $this->app['config']['mailbox.driver'];
+        return $this->container['config']['mailbox.driver'];
     }
 }


### PR DESCRIPTION
This fixes Laravel 8 support because $app has been deprecated since Laravel 6.x and was removed and replaced with $container for the Illuminate\Support\Manager class in Laravel 8.