### PR TITLE
Added SES Driver

### DIFF
--- a/src/Drivers/Ses.php
+++ b/src/Drivers/Ses.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BeyondCode\Mailbox\Drivers;
+
+use BeyondCode\Mailbox\Http\Controllers\SesController;
+use Illuminate\Support\Facades\Route;
+
+class Ses implements DriverInterface
+{
+    public function register()
+    {
+        Route::prefix(config('mailbox.path'))->group(function () {
+            Route::post('/ses', SesController::class);
+        });
+    }
+}

--- a/src/Http/Controllers/SesController.php
+++ b/src/Http/Controllers/SesController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BeyondCode\Mailbox\Http\Controllers;
+
+use BeyondCode\Mailbox\Facades\Mailbox;
+use BeyondCode\Mailbox\Http\Requests\MailCareRequest;
+use BeyondCode\Mailbox\Http\Requests\SesRequest;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class SesController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('laravel-mailbox');
+    }
+
+    public function __invoke(SesRequest $request)
+    {
+        Mailbox::callMailboxes($request->email());
+    }
+}

--- a/src/Http/Middleware/MailboxBasicAuthentication.php
+++ b/src/Http/Middleware/MailboxBasicAuthentication.php
@@ -16,6 +16,6 @@ class MailboxBasicAuthentication
             return $next($request);
         }
 
-        throw new UnauthorizedHttpException('Laravel Mailbox');
+        throw new UnauthorizedHttpException('Basic realm=Mailer','Laravel Mailbox');
     }
 }

--- a/src/Http/Requests/SesRequest.php
+++ b/src/Http/Requests/SesRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BeyondCode\Mailbox\Http\Requests;
+
+use BeyondCode\Mailbox\InboundEmail;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Validator;
+
+class SesRequest extends FormRequest
+{
+    public function validator()
+    {
+        return Validator::make(json_decode($this->getContent(), true), [
+            'Message' => 'required',
+        ]);
+    }
+
+    public function email()
+    {
+        /** @var InboundEmail $modelClass */
+        $modelClass = config('mailbox.model');
+
+        return $modelClass::fromMessage(json_decode(json_decode($this->getContent(), true)['Message'],true)['content']);
+    }
+}

--- a/src/MailboxManager.php
+++ b/src/MailboxManager.php
@@ -7,6 +7,7 @@ use BeyondCode\Mailbox\Drivers\MailCare;
 use BeyondCode\Mailbox\Drivers\Mailgun;
 use BeyondCode\Mailbox\Drivers\Postmark;
 use BeyondCode\Mailbox\Drivers\SendGrid;
+use BeyondCode\Mailbox\Drivers\Ses;
 use Illuminate\Support\Manager;
 
 class MailboxManager extends Manager
@@ -39,6 +40,11 @@ class MailboxManager extends Manager
     public function createPostmarkDriver()
     {
         return new Postmark;
+    }
+
+    public function createSESDriver()
+    {
+        return new Ses;
     }
 
     public function getDefaultDriver()


### PR DESCRIPTION
Hello,
This PR basically adds SES support to Laravel Mailbox. It is overcoming few shortcomings from Amazon SNS.

1. The POST request from SNS has content-type as text instead of JSON.
2. SNS posts a request first without the Authorization header, and expects a response of 401 Unauthorized and Realm.

Appreciate your review and comments.