### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "zbateson/mail-mime-parser": "^1.1"
     },
     "require-dev": {
+        "laminas/laminas-mail": "^2.10",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4.0|^5.0",
-        "phpunit/phpunit": "^7.0|^8.0",
-        "zendframework/zend-mail": "^2.10"
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +44,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/container": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
         "illuminate/log": "^6.0|^7.0|^8.0",
@@ -29,7 +29,7 @@
         "laminas/laminas-mail": "^2.13",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4.0|^5.0",
-        "phpunit/phpunit": "^7.0|^8.0"
+        "phpunit/phpunit": "^7.0|^8.0|^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "zbateson/mail-mime-parser": "^1.1"
     },
     "require-dev": {
-        "laminas/laminas-mail": "^2.10",
+        "laminas/laminas-mail": "^2.13",
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "^4.0|^5.0",
         "phpunit/phpunit": "^7.0|^8.0"

--- a/tests/MailboxRouteCollectionTest.php
+++ b/tests/MailboxRouteCollectionTest.php
@@ -5,7 +5,7 @@ namespace BeyondCode\Mailbox\Tests;
 use BeyondCode\Mailbox\InboundEmail;
 use BeyondCode\Mailbox\Routing\Route;
 use BeyondCode\Mailbox\Routing\RouteCollection;
-use Zend\Mail\Message as TestMail;
+use Laminas\Mail\Message as TestMail;
 
 class MailboxRouteCollectionTest extends TestCase
 {

--- a/tests/MailboxRouteTest.php
+++ b/tests/MailboxRouteTest.php
@@ -4,7 +4,7 @@ namespace BeyondCode\Mailbox\Tests;
 
 use BeyondCode\Mailbox\InboundEmail;
 use BeyondCode\Mailbox\Routing\Route;
-use Zend\Mail\Message as TestMail;
+use Laminas\Mail\Message as TestMail;
 
 class MailboxRouteTest extends TestCase
 {


### PR DESCRIPTION
Move composer dependency [zendframework/zend-mail](https://github.com/zendframework/zend-mail) to [laminas/laminas-mail](https://github.com/laminas/laminas-mail) due to [Zend Framework migration](https://www.zend.com/blog/evolution-zend-framework-laminas-project).

Upgraded the tests to use the new `Laminas` namespace. 

This will help to speed things up when they add PHP 8 support (see https://github.com/laminas/laminas-mail/pull/117) to fix issue https://github.com/beyondcode/laravel-mailbox/issues/78 ;)

Edit, March 9 2021: now that Laminas added support for PHP 8, I updated the `composer.json` php versions and renamed the PR from _"Migrate composer dependency from Zend to Laminas"_ to _"Add PHP 8.0 support"_