### PR TITLE
Added isAutoReply() method to InboundEmail

### DIFF
--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -185,4 +185,43 @@ class InboundEmail extends Model
     {
         return $this->from() !== '' && ($this->isText() || $this->isHtml());
     }
+    
+    public function isAutoReply($checkCommonSubjects = true): bool
+    {
+        if ($this->headerValue('x-autorespond')) {
+            return true;
+        }
+
+        if (in_array($this->headerValue('precedence'), ['auto_reply', 'bulk', 'junk'])) {
+            return true;
+        }
+
+        if (in_array($this->headerValue('x-precedence'), ['auto_reply', 'bulk', 'junk'])) {
+            return true;
+        }
+        if (in_array($this->headerValue('auto-submitted'), ['auto-replied', 'auto-generated'])) {
+            return true;
+        }
+
+        if ($checkCommonSubjects) {
+            return Str::startsWith($this->subject(), [
+                'Auto:',
+                'Automatic reply',
+                'Autosvar',
+                'Automatisk svar',
+                'Automatisch antwoord',
+                'Abwesenheitsnotiz',
+                'Risposta Non al computer',
+                'Automatisch antwoord',
+                'Auto Response',
+                'Respuesta automática',
+                'Fuori sede',
+                'Out of Office',
+                'Frånvaro',
+                'Réponse automatique',
+            ]);
+        }
+
+        return false;
+    }
 }

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -185,7 +185,7 @@ class InboundEmail extends Model
     {
         return $this->from() !== '' && ($this->isText() || $this->isHtml());
     }
-    
+
     public function isAutoReply($checkCommonSubjects = true): bool
     {
         if ($this->headerValue('x-autorespond')) {


### PR DESCRIPTION
### Description
This new method `->isAutoReply()` checks several email headers and/or the email subject line if it matches commonly used patterns that indicate that this email is an automatic reply to another email (also known as "Out-of-office-reply").

Checking the subject line is less accurate and can optionally be disabled by calling  `->isAutoReply(false)`.

###  Background

Not all email clients/servers use the same header/subject formats when replying automatically. This method checks the most common ones. Also see: https://stackoverflow.com/questions/1027395/detecting-outlook-autoreply-out-of-office-emails

### Example usage
```php
Mailbox::from('sender@domain.com', function (InboundEmail $email) {

  // Only reply to email, if it's not an auto-reply
  if(! $email->isAutoReply()){
    $email->reply(new FeedbackReceived);
  }

});
```