### PR TITLE
Use "Reply-To"-address, if available

### DIFF
--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -154,7 +154,7 @@ class InboundEmail extends Model
             });
         }
 
-        return Mail::to($this->from())->send($mailable);
+        return Mail::to($this->headerValue('Reply-To') ?? $this->from())->send($mailable);
     }
 
     public function forward($recipients)


### PR DESCRIPTION
### Description
When using the `$email->reply()` method, instead of automatically replying the the `From` address, check first if the sender provided a `Reply-To` address and use this instead.