### PR TITLE
Save email before calling the routes

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -87,7 +87,7 @@ class Router
             if ($this->shouldStoreInboundEmails() && $this->shouldStoreAllInboundEmails($matchedRoutes)) {
                 $this->storeEmail($email);
             }
-            
+
             $matchedRoutes = $this->routes->match($email)->map(function (Route $route) use ($email) {
                 $route->run($email);
             });

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -84,6 +84,10 @@ class Router
     public function callMailboxes(InboundEmail $email)
     {
         if ($email->isValid()) {
+            if ($this->shouldStoreInboundEmails() && $this->shouldStoreAllInboundEmails($matchedRoutes)) {
+                $this->storeEmail($email);
+            }
+            
             $matchedRoutes = $this->routes->match($email)->map(function (Route $route) use ($email) {
                 $route->run($email);
             });
@@ -96,10 +100,6 @@ class Router
             if ($this->catchAllRoute) {
                 $matchedRoutes[] = $this->catchAllRoute;
                 $this->catchAllRoute->run($email);
-            }
-
-            if ($this->shouldStoreInboundEmails() && $this->shouldStoreAllInboundEmails($matchedRoutes)) {
-                $this->storeEmail($email);
             }
         }
     }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -84,11 +84,13 @@ class Router
     public function callMailboxes(InboundEmail $email)
     {
         if ($email->isValid()) {
+            $matchedRoutes = $this->routes->match($email);
+
             if ($this->shouldStoreInboundEmails() && $this->shouldStoreAllInboundEmails($matchedRoutes)) {
                 $this->storeEmail($email);
             }
 
-            $matchedRoutes = $this->routes->match($email)->map(function (Route $route) use ($email) {
+            $matchedRoutes->map(function (Route $route) use ($email) {
                 $route->run($email);
             });
 


### PR DESCRIPTION
If a route throws an Exception, then the email is lost because it won't be saved in the database.

Saving the email before calling the actual route prevents losing messages.
This also fixes #48.