### PR TITLE
Fix memory limit issues when running mailbox:cleanup

### DIFF
--- a/src/Console/CleanEmails.php
+++ b/src/Console/CleanEmails.php
@@ -29,7 +29,7 @@ class CleanEmails extends Command
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
 
-        $models = $modelClass::where('created_at', '<', $cutOffDate)->get();
+        $models = $modelClass::where('created_at', '<', $cutOffDate)->get('id');
 
         $models->each->delete();
 

--- a/src/Console/CleanEmails.php
+++ b/src/Console/CleanEmails.php
@@ -29,11 +29,7 @@ class CleanEmails extends Command
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
 
-        $models = $modelClass::where('created_at', '<', $cutOffDate)->get('id');
-
-        $models->each->delete();
-
-        $amountDeleted = $models->count();
+        $amountDeleted = $modelClass::where('created_at', '<', $cutOffDate)->delete();
 
         $this->info("Deleted {$amountDeleted} record(s) from the Mailbox logs.");
 


### PR DESCRIPTION
I sometimes get a memory limit error when running `mailbox:cleanup` since the command fetches all columns of the table which includes entire emails + raw attachments, this PR optimizes the command to run the `delete` statement right on the database level.