### PR TITLE
Add testing array driver

### DIFF
--- a/config/mailbox.php
+++ b/config/mailbox.php
@@ -6,9 +6,9 @@ return [
      * The driver to use when listening for incoming emails.
      * It defaults to the mail driver that you are using.
      *
-     * Supported drivers: "log", "mailgun", "sendgrid", "postmark"
+     * Supported drivers: "mailgun", "sendgrid", "postmark", "array"
      */
-    'driver' => env('MAILBOX_DRIVER', 'log'),
+    'driver' => env('MAILBOX_DRIVER', 'array'),
 
     /*
      * The model class to use when converting an incoming email to a message.

--- a/docs/drivers/drivers.md
+++ b/docs/drivers/drivers.md
@@ -62,9 +62,15 @@ Next you will need to configure MailCare, to send incoming emails to your applic
 
 See ["MailCare"](https://mailcare.io) for more information.
 
-## Local development / log driver
+## Local development
 
-When working locally, you might not want to use real incoming emails while testing your application. Out of the box, this package supports Laravel's "log" mail driver for incoming emails.
+When working locally, you might not want to use real emails while testing your application. Out of the box, this package supports Laravel's "log" and "array" mail drivers.
 
-To test incoming emails, set both your `MAIL_DRIVER` and your `MAILBOX_DRIVER`  in your `.env` file to "log".
-Now every time you send an email in your application, this email will appear in your `laravel.log` file and will try to call one of your configured Mailboxes.
+You can update your `.env` or `phpunit.xml` file:
+
+```xml
+<server name="MAIL_MAILER" value="array"/>
+<server name="MAILBOX_DRIVER" value="array"/>
+```
+
+If you want to log the emails (inside `storage/logs/laravel.log`), then set your Laravel `MAIL_MAILER` to "log".

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,9 +40,9 @@ return [
      * The driver to use when listening for incoming emails.
      * It defaults to the mail driver that you are using.
      *
-     * Supported drivers: "log", "mailgun", "sendgrid"
+     * Supported drivers: "mailgun", "sendgrid", "postmark", "array"
      */
-    'driver' => env('MAILBOX_DRIVER', 'log'),
+    'driver' => env('MAILBOX_DRIVER', 'array'),
 
     /*
      * The path for driver specific routes. This is where

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
     <php>
-        <env name="MAIL_MAILER" value="log"/>
+        <env name="MAIL_MAILER" value="array"/>
         <env name="DB_CONNECTION" value="testing"/>
     </php>
 </phpunit>

--- a/src/Drivers/ArrayDriver.php
+++ b/src/Drivers/ArrayDriver.php
@@ -6,19 +6,15 @@ use BeyondCode\Mailbox\Facades\Mailbox;
 use BeyondCode\Mailbox\InboundEmail;
 use Illuminate\Mail\Events\MessageSent;
 
-class Log implements DriverInterface
+class ArrayDriver implements DriverInterface
 {
     public function register()
     {
-        app('events')->listen(MessageSent::class, [$this, 'processLog']);
+        app('events')->listen(MessageSent::class, [$this, 'processArray']);
     }
 
-    public function processLog(MessageSent $event)
+    public function processArray(MessageSent $event)
     {
-        if (config('mail.driver') !== 'log' && config('mail.default') !== 'log') {
-            return;
-        }
-
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
         $email = $modelClass::fromMessage($event->message);

--- a/src/MailboxManager.php
+++ b/src/MailboxManager.php
@@ -2,7 +2,7 @@
 
 namespace BeyondCode\Mailbox;
 
-use BeyondCode\Mailbox\Drivers\Log;
+use BeyondCode\Mailbox\Drivers\ArrayDriver;
 use BeyondCode\Mailbox\Drivers\MailCare;
 use BeyondCode\Mailbox\Drivers\Mailgun;
 use BeyondCode\Mailbox\Drivers\Postmark;
@@ -14,11 +14,6 @@ class MailboxManager extends Manager
     public function mailbox($name = null)
     {
         return $this->driver($name);
-    }
-
-    public function createLogDriver()
-    {
-        return new Log;
     }
 
     public function createMailgunDriver()
@@ -39,6 +34,17 @@ class MailboxManager extends Manager
     public function createPostmarkDriver()
     {
         return new Postmark;
+    }
+
+    /** @deprecated */
+    public function createLogDriver()
+    {
+        return $this->createArrayDriver();
+    }
+
+    public function createArrayDriver()
+    {
+        return new ArrayDriver;
     }
 
     public function getDefaultDriver()

--- a/tests/Drivers/ArrayTest.php
+++ b/tests/Drivers/ArrayTest.php
@@ -8,19 +8,25 @@ use BeyondCode\Mailbox\Tests\TestCase;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
 
-class LogTest extends TestCase
+class ArrayTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
+    /** @test */
+    public function it_catches_in_memory_array_mails()
     {
-        parent::getEnvironmentSetUp($app);
+        Mailbox::from('{name}@beyondco.de', function (InboundEmail $email, $name) {
+            $this->assertSame($name, 'example');
+            $this->assertSame($email->from(), 'example@beyondco.de');
+            $this->assertSame($email->subject(), 'This is a subject');
+        });
 
-        $app['config']['mail.driver'] = 'log';
-        $app['config']['mailbox.driver'] = 'log';
+        Mail::to('someone@beyondco.de')->send(new TestMail);
     }
 
     /** @test */
     public function it_catches_logged_mails()
     {
+        $app['config']['mail.driver'] = 'log';
+
         Mailbox::from('{name}@beyondco.de', function (InboundEmail $email, $name) {
             $this->assertSame($name, 'example');
             $this->assertSame($email->from(), 'example@beyondco.de');

--- a/tests/InboundEmailTest.php
+++ b/tests/InboundEmailTest.php
@@ -9,14 +9,6 @@ use Illuminate\Support\Facades\Mail;
 
 class InboundEmailTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-
-        $app['config']['mail.driver'] = 'log';
-        $app['config']['mailbox.driver'] = 'log';
-    }
-
     /** @test */
     public function it_stores_inbound_emails()
     {


### PR DESCRIPTION
Add support for new `MAILBOX_DRIVER` in-memory "array" driver. It's now the default config.

Deprecate unnecessary `MAILBOX_DRIVER` "log" driver.
If I'm not mistaking, Mailbox doesn't log any emails. Only the Laravel `MAIL_MAILER` does.

So I believe most people would use these testing environment variables (inside `phpunit.xml`):

```xml
<server name="MAIL_MAILER" value="array"/>
<server name="MAILBOX_DRIVER" value="array"/>
```

Or if they want to log the test emails:
```xml
<server name="MAIL_MAILER" value="log"/>
<server name="MAILBOX_DRIVER" value="array"/>
```

Fixes issue https://github.com/beyondcode/laravel-mailbox/issues/72