### PR TITLE
Support for laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,20 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0]
-                laravel: [9.*, 8.*]
                 stability: [prefer-stable]
                 include:
                     -   laravel: 9.*
                         testbench: 7.*
+                        php: 8.0
                     -   laravel: 8.*
                         testbench: 6.23
+                        php: 8.0
+                    -   laravel: 7.*
+                        testbench: 6.23
+                        php: 7.3
+                    -   laravel: 6.*
+                        testbench: 6.23
+                        php: 7.3
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [7.3,8.0]
+                php: [8.0]
                 laravel: [9.*, 8.*]
                 stability: [prefer-stable]
                 include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,46 @@
+name: run-tests
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: true
+            matrix:
+                os: [ubuntu-latest]
+                php: [7.3,8.0]
+                laravel: [9.*, 8.*]
+                stability: [prefer-stable]
+                include:
+                    -   laravel: 9.*
+                        testbench: 7.*
+                    -   laravel: 8.*
+                        testbench: 6.23
+
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                    coverage: none
+
+#            - name: Setup problem matchers
+#              run: |
+#                  echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+#                  echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+#
+            -   name: Install dependencies
+                run: |
+                    composer install
+                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+            -   name: Execute tests
+                run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,19 +12,22 @@ jobs:
                 php: [7.3, 8.0, 8.1]
                 laravel: [9.*, 8.*, 7.*, 6.*]
                 stability: [prefer-stable]
+                exclude:
+                    -   php: 7.3
+                        laravel: 9.*
+                    -   php: 8.1
+                        laravel: 7.*
+                    -   php: 8.1
+                        laravel: 6.*
                 include:
                     -   laravel: 9.*
                         testbench: 7.*
-                        php: 8.0
                     -   laravel: 8.*
                         testbench: 6.23
-                        php: 8.0
                     -   laravel: 7.*
                         testbench: 5.20.0
-                        php: 7.3
                     -   laravel: 6.*
                         testbench: 4.18.0
-                        php: 7.3
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,8 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [7.3 8.0]
+                php: [7.3, 8.0, 8.1]
+                laravel: [9.*, 8.*, 7.*, 6.*]
                 stability: [prefer-stable]
                 include:
                     -   laravel: 9.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
+                php: [7.3 8.0]
                 stability: [prefer-stable]
                 include:
                     -   laravel: 9.*
@@ -18,10 +19,10 @@ jobs:
                         testbench: 6.23
                         php: 8.0
                     -   laravel: 7.*
-                        testbench: 6.23
+                        testbench: 5.20.0
                         php: 7.3
                     -   laravel: 6.*
-                        testbench: 6.23
+                        testbench: 4.18.0
                         php: 7.3
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
     test:
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
                 php: [7.3, 8.0, 8.1]

--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -19,9 +19,15 @@ class Log implements DriverInterface
             return;
         }
 
+        if(app()->version() >= 9) {
+            $message = $event->sent->toString();
+        } else {
+            $message = $event->message;
+        }
+
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
-        $email = $modelClass::fromMessage($event->message);
+        $email = $modelClass::fromMessage($message);
 
         Mailbox::callMailboxes($email);
     }

--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -19,7 +19,7 @@ class Log implements DriverInterface
             return;
         }
 
-        if(app()->version() >= 9) {
+        if (app()->version() >= 9) {
             $message = $event->sent->toString();
         } else {
             $message = $event->message;

--- a/src/Drivers/Log.php
+++ b/src/Drivers/Log.php
@@ -19,11 +19,7 @@ class Log implements DriverInterface
             return;
         }
 
-        if (app()->version() >= 9) {
-            $message = $event->sent->toString();
-        } else {
-            $message = $event->message;
-        }
+        $message = version_compare(app()->version(), '9.0.0', '>') ? $event->sent->toString() : $event->message;
 
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -149,18 +149,20 @@ class InboundEmail extends Model
     public function reply(Mailable $mailable)
     {
         if ($mailable instanceof \Illuminate\Mail\Mailable) {
-            if (app()->version() >= 9) {
-                $mailable->withSwiftMessage(function (\Swift_Message $message) {
-                    $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
+            $usesSymfonyMailer = version_compare(app()->version(), '9.0.0', '>');
+
+            if ($usesSymfonyMailer) {
+                $mailable->withSymfonyMessage(function (\Symfony\Component\Mime\Email $email) {
+                    $email->getHeaders()->addIdHeader('In-Reply-To', $this->id());
                 });
             } else {
-                $mailable->withSymfonyMessage(function (\Swift_Message $message) {
+                $mailable->withSwiftMessage(function (\Swift_Message $message) {
                     $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
                 });
             }
         }
 
-        return Mail::to($this->from())->send($mailable);
+        return Mail::to($this->headerValue('Reply-To') ?: $this->from())->send($mailable);
     }
 
     public function forward($recipients)

--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -149,9 +149,15 @@ class InboundEmail extends Model
     public function reply(Mailable $mailable)
     {
         if ($mailable instanceof \Illuminate\Mail\Mailable) {
-            $mailable->withSwiftMessage(function (\Swift_Message $message) {
-                $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
-            });
+            if (app()->version() >= 9) {
+                $mailable->withSwiftMessage(function (\Swift_Message $message) {
+                    $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
+                });
+            } else {
+                $mailable->withSymfonyMessage(function (\Swift_Message $message) {
+                    $message->getHeaders()->addIdHeader('In-Reply-To', $this->id());
+                });
+            }
         }
 
         return Mail::to($this->from())->send($mailable);


### PR DESCRIPTION
I saw that the composer.json was updated in master to support Laravel 9 but there are a couple of other changes necessary to support L9 since the Swift Mailer was replaced with the Symfony Mailer. 

The Log driver and InboundEmail files needed updates.
I implemented to be backward compatible by checking the app()->version() in each instance.
I also added a run-tests action to test against L6-9 on php 7.3, 8 and 8.1
I confirmed that all tests failed prior to my changes and they all pass on all supported php/laravel combinations.