### PR TITLE
Update zbateson/mail-mime-parser to ^1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "willdurand/email-reply-parser": "^2.8",
-        "zbateson/mail-mime-parser": "^1.1"
+        "zbateson/mail-mime-parser": "^1.2"
     },
     "require-dev": {
         "laminas/laminas-mail": "^2.13",


### PR DESCRIPTION
👋

Related issue: https://github.com/zbateson/stream-decorators/issues/16

`zbateson/mail-mime-parser` recently released `1.2.0` which adds type annotations for the methods overridden from  `guzzlehttp/psr7`.

This PR updates this library to ^1.2 to address potential runtime errors.