### PR TITLE
Added mailbox support for 'X-Forwarded-To' address

### DIFF
--- a/src/InboundEmail.php
+++ b/src/InboundEmail.php
@@ -109,6 +109,14 @@ class InboundEmail extends Model
     /**
      * @return AddressPart[]
      */
+    public function xForwardedTo(): array
+    {
+        return $this->convertAddressHeader($this->message()->getHeader('X-Forwarded-To'));
+    }
+
+    /**
+     * @return AddressPart[]
+     */
     public function cc(): array
     {
         return $this->convertAddressHeader($this->message()->getHeader('Cc'));

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -20,6 +20,7 @@ class Route
 
     const FROM = 'from';
     const TO = 'to';
+    const X_FORWARDED_TO = 'x-forwarded-to';
     const CC = 'cc';
     const BCC = 'bcc';
     const SUBJECT = 'subject';
@@ -87,6 +88,9 @@ class Route
             case self::TO:
                 return $this->convertMessageAddresses($message->to());
             break;
+            case self::X_FORWARDED_TO:
+                return $this->convertMessageAddresses($message->xForwardedTo());
+                break;
             case self::CC:
                 return $this->convertMessageAddresses($message->cc());
             break;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -41,6 +41,11 @@ class Router
         return $this->addRoute(Route::TO, $pattern, $action);
     }
 
+    public function xForwardedTo(string $pattern, $action): Route
+    {
+        return $this->addRoute(Route::X_FORWARDED_TO, $pattern, $action);
+    }
+
     public function cc(string $pattern, $action): Route
     {
         return $this->addRoute(Route::CC, $pattern, $action);


### PR DESCRIPTION
Added support for using the X-Forwarded-To header in the mailbox facade and the model. This header becomes very useful when using filters in inboxes from Gmail, Outlook etc. that forwards emails. When emails are forwarded this way, the 'to' array does not contain the email address of where the email was forwarded to, the X-Forwarded-Headers does.