### PR TITLE
Fix implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -24,7 +24,7 @@ class Router
     /** @var Container */
     protected $container;
 
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->container = $container ?: new Container;
 


### PR DESCRIPTION
See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated