### PR TITLE
Fix for a deprecated parameter:

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -24,7 +24,7 @@ class Router
     /** @var Container */
     protected $container;
 
-    public function __construct(?Container $container = null)
+    public function __construct(?Container $container)
     {
         $this->container = $container ?: new Container;
 


### PR DESCRIPTION
"Implicitly marking parameter $container as nullable is deprecated, the explicit nullable type must be used instead"